### PR TITLE
fix: "previous versions" button failing after transpose

### DIFF
--- a/app/views/chord_sheets/_main.html.slim
+++ b/app/views/chord_sheets/_main.html.slim
@@ -21,7 +21,7 @@ turbo-frame[id=dom_id(chord_sheet) data-controller="clipboard chord-diagram moda
               span.icon
                 i.fas.fa-arrow-circle-down
 
-        .level-right.align-items-space-between
+        .level-right.align-items-space-between#level-right[data-turbo-permanent]
           .level-item.mt-2 data-chord-diagram-target="wrapper"
             = render("chord_diagram_icon")
             .hidden#diagram-select data-chord-diagram-target="selectBox"

--- a/spec/cypress/e2e/chord_sheets.cy.js
+++ b/spec/cypress/e2e/chord_sheets.cy.js
@@ -120,6 +120,13 @@ describe("Undoing changes", () => {
     cy.get("#versions").click()
 
     cy.contains("My amazing song")
+
+    cy.get(".modal-close").click()
+    cy.get("#transpose-up").click() // even after transposing
+
+    cy.get("#versions").click()
+
+    cy.contains("My amazing song")
   })
 
   it("allows the user to restore a previous version", () => {


### PR DESCRIPTION
this change stops the button from refreshing (or being replaced) and losing its event listener for opening the modal.

I found two other ways to fix this:
1. wrapping the chord sheet content in a turbo frame and targeting that turbo frame from the "Previous versions" button.
2. changing the transpose button to cause a full page reload. This one made the experience janky, so I didn't like it.

I'd like to hear your thoughts on the issue. I suspected the modal controller was getting disconnected after transposing, but that wasn't the case. The connection remained, but the button defaulted to sending a post request.

I also considered changing the button method to get, using a link, or even using a plain HTML button (no request will be sent) so it wouldn't cause the server error, but I don't know how useful that would be if the button's intended function weren't happening. 

Lastly, I noticed the bug was a little different in prod. It looked like what you'd get if there were no matching turbo frame in the response. Still, I reckon that's better than the error in main.